### PR TITLE
Support dbg

### DIFF
--- a/platform/Taskfile.yaml
+++ b/platform/Taskfile.yaml
@@ -3,7 +3,38 @@
 version: '3'
 
 tasks:
-  default:
-    desc: Some description here ...
+  build-roc:
     cmds:
-      - echo Hello
+      - rm -f roc.o
+      - roc build  example/main.roc --no-link --output roc.o
+    sources:
+      - example/main.roc
+    generates:
+      - roc.o
+
+  build-go:
+    cmds:
+      - rm -f webserver
+      - go build
+    sources:
+      - main.go
+      - "*/*.go"
+      - roc/host.h
+      - roc.o
+    generates:
+      - webserver
+    deps:
+      - build-roc
+
+  build:
+    deps:
+      - build-roc
+      - build-go
+
+  run:
+    sources:
+      - webserver
+    deps:
+      - build-go
+    cmds:
+      - ./webserver

--- a/platform/example/main.roc
+++ b/platform/example/main.roc
@@ -40,6 +40,7 @@ handleReadRequest = \request, model ->
             Body str -> "Body: $(str.body |> Str.fromUtf8 |> Result.withDefault "invalid utf8")"
 
     url = request.url
+    dbg url
 
     {
         body: Str.concat allHeaders model |> Str.concat hasBody |> Str.concat url |> Str.toUtf8,

--- a/platform/roc/roc.go
+++ b/platform/roc/roc.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"sync"
 	"unsafe"
 
@@ -343,4 +344,17 @@ func roc_dealloc(ptr unsafe.Pointer, alignment int) {
 //export roc_panic
 func roc_panic(msg *C.struct_RocStr, tagID C.uint) {
 	panic(fmt.Sprintf(rocStrRead(*msg)))
+}
+
+//export roc_dbg
+func roc_dbg(loc *C.struct_RocStr, msg *C.struct_RocStr, src *C.struct_RocStr) {
+	locStr := rocStrRead(*loc)
+	msgStr := rocStrRead(*msg)
+	srcStr := rocStrRead(*src)
+
+	if srcStr == msgStr {
+		fmt.Fprintf(os.Stderr, "[%s] {%s}\n", locStr, msgStr)
+	} else {
+		fmt.Fprintf(os.Stderr, "[%s] {%s} = {%s}\n", locStr, srcStr, msgStr)
+	}
 }


### PR DESCRIPTION
This gives the go code the possibility to print dbg statements, if they are included in the roc.o file...

Currently, doc does not include any dbg statements, when `roc build` was used. Since this is the only way we can create our app, roc has to be changed. I already ask for it in the chat. For the moment, it is very easy to change the roc-sourcecode

Just change this value from `false` to `true`: 
https://github.com/roc-lang/roc/blob/c63b6ca507fd401a94bde083c764e05054d9de08/crates/compiler/gen_llvm/src/llvm/build.rs#L722 